### PR TITLE
Fix plot_cad compatiblity issue with OCP 7.9

### DIFF
--- a/src/pyvista_cad/_cad_view.py
+++ b/src/pyvista_cad/_cad_view.py
@@ -354,8 +354,8 @@ def topods_to_edges(
                 eexp.Next()
                 continue
             offset = len(points)
-            for k in range(node_idx.Lower(), node_idx.Upper() + 1):
-                node = tri.Node(node_idx.Value(k))
+            for k in node_idx:
+                node = tri.Node(k)
                 node.Transform(trsf)
                 points.append((node.X(), node.Y(), node.Z()))
             lines.append(n)

--- a/tests/test_cad_view.py
+++ b/tests/test_cad_view.py
@@ -51,18 +51,25 @@ def test_topods_to_edges_returns_polylines(block_with_hole):
 
 
 def test_topods_to_edges_node_coordinates_are_finite(block_with_hole):
-    """Regression: TColStd_Array1OfInteger iteration must yield node indices
-    directly (not via .Value()), otherwise point coordinates are garbage or
-    an AttributeError/TypeError is raised on OCP 7.8+.
+    """Regression: ``TColStd_Array1OfInteger`` iteration yields node indices directly.
+
+    On OCP 7.8+, iterating a ``TColStd_Array1OfInteger`` yields the array
+    values themselves. The previous code took a 1-based ``range(Lower, Upper+1)``
+    counter and passed it back through ``node_idx.Value(k)``, treating an int as
+    a wrapper; that produced garbage coordinates or raised
+    ``AttributeError``/``TypeError`` on OCP 7.8+.
     """
     edges = topods_to_edges(block_with_hole, linear_deflection=0.3)
     pts = edges.points
     assert pts.shape[1] == 3
     assert np.all(np.isfinite(pts)), 'edge point coordinates must be finite'
-    # The box is 20×12×8 mm; all coordinates must lie within its bounding box.
-    assert pts[:, 0].min() >= -0.1 and pts[:, 0].max() <= 20.1
-    assert pts[:, 1].min() >= -0.1 and pts[:, 1].max() <= 12.1
-    assert pts[:, 2].min() >= -0.1 and pts[:, 2].max() <= 8.1
+    # Source block is 20 by 12 by 8 mm; every coordinate must lie inside it.
+    assert pts[:, 0].min() >= -0.1
+    assert pts[:, 0].max() <= 20.1
+    assert pts[:, 1].min() >= -0.1
+    assert pts[:, 1].max() <= 12.1
+    assert pts[:, 2].min() >= -0.1
+    assert pts[:, 2].max() <= 8.1
 
 
 def test_edge_kind_classifies_lines_and_circles(block_with_hole):

--- a/tests/test_cad_view.py
+++ b/tests/test_cad_view.py
@@ -50,6 +50,21 @@ def test_topods_to_edges_returns_polylines(block_with_hole):
     assert len(np.unique(edges.cell_data['cad.edge_id'])) == edges.n_cells
 
 
+def test_topods_to_edges_node_coordinates_are_finite(block_with_hole):
+    """Regression: TColStd_Array1OfInteger iteration must yield node indices
+    directly (not via .Value()), otherwise point coordinates are garbage or
+    an AttributeError/TypeError is raised on OCP 7.8+.
+    """
+    edges = topods_to_edges(block_with_hole, linear_deflection=0.3)
+    pts = edges.points
+    assert pts.shape[1] == 3
+    assert np.all(np.isfinite(pts)), 'edge point coordinates must be finite'
+    # The box is 20×12×8 mm; all coordinates must lie within its bounding box.
+    assert pts[:, 0].min() >= -0.1 and pts[:, 0].max() <= 20.1
+    assert pts[:, 1].min() >= -0.1 and pts[:, 1].max() <= 12.1
+    assert pts[:, 2].min() >= -0.1 and pts[:, 2].max() <= 8.1
+
+
 def test_edge_kind_classifies_lines_and_circles(block_with_hole):
     edges = topods_to_edges(block_with_hole, linear_deflection=0.3)
     kinds = set(np.unique(edges.cell_data['cad.edge_kind']).tolist())


### PR DESCRIPTION
Hi,

just discovered this library, looks very promising!

My first attempt at visualizing an object created with `build123d` (based on OCP like Cadquery) directly with `plot_cad` failed because `topods_to_edges` uses an old OCP API (before v7.8), even though the TOML pins v7.9+. Confirmed fixed with this PR, unit test that would have caught it added.