### PR TITLE
Re-enable Python 3.14 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,12 +41,6 @@ jobs:
       # specifics (DLL/dylib loaders, path handling). Skipping the
       # middle Pythons on macOS/Windows trades a slim regression
       # surface for ~3× fewer billed jobs.
-      #
-      # 3.14 is intentionally absent: every test extra transitively
-      # pulls `cadquery` (dev -> docs -> full -> cadquery), and
-      # `cadquery-ocp` ships no cp314 wheel for any platform/version,
-      # so the env is uninstallable on 3.14. Re-add once cadquery-ocp
-      # publishes cp314 wheels. requires-python stays `>=3.10`.
       matrix:
         include:
           # Ubuntu — full Python sweep × all extras
@@ -54,17 +48,18 @@ jobs:
           - { os: ubuntu-latest, python-version: "3.11", extras: "dev" }
           - { os: ubuntu-latest, python-version: "3.12", extras: "dev" }
           - { os: ubuntu-latest, python-version: "3.13", extras: "dev" }
+          - { os: ubuntu-latest, python-version: "3.14", extras: "dev" }
           - { os: ubuntu-latest, python-version: "3.10", extras: "dev,step" }
-          - { os: ubuntu-latest, python-version: "3.13", extras: "dev,step" }
+          - { os: ubuntu-latest, python-version: "3.14", extras: "dev,step" }
           # Coverage upload cell.
-          - { os: ubuntu-latest, python-version: "3.13", extras: "dev,full,step-light", coverage: true }
+          - { os: ubuntu-latest, python-version: "3.14", extras: "dev,full,step-light", coverage: true }
           # macOS — minimal: lowest + highest Python only
           - { os: macos-14, python-version: "3.10", extras: "dev" }
-          - { os: macos-14, python-version: "3.13", extras: "dev,step" }
+          - { os: macos-14, python-version: "3.14", extras: "dev,step" }
           # Windows — minimal; `dev,full,step-light` already excluded
           # historically because cascadio lacks Windows wheels.
           - { os: windows-latest, python-version: "3.10", extras: "dev" }
-          - { os: windows-latest, python-version: "3.13", extras: "dev,step" }
+          - { os: windows-latest, python-version: "3.14", extras: "dev,step" }
     steps:
       - uses: actions/checkout@v4
         with:

--- a/README.md
+++ b/README.md
@@ -29,9 +29,7 @@
 | `[openscad]`   | (uses `openscad` CLI)   | SCAD read                           |
 | `[full]`       | all of the above        | every supported format              |
 
-**Python support:** 3.10 – 3.13. Python 3.14 is not yet supported: the
-`[step]`/`[full]` extras depend on `cadquery-ocp`, which publishes no
-cp314 wheels for any platform. 3.14 will be added once those wheels ship.
+**Python support:** 3.10 – 3.14.
 
 trimesh interop is provided by pyvista core (`pyvista.from_trimesh`, `pyvista.to_trimesh`) and the `pyvista-trimesh` package's `.trimesh` accessor (install `pyvista-cad[trimesh]`); pyvista-cad does not duplicate it.
 


### PR DESCRIPTION
`cadquery-ocp` 7.9.3.1.1 now ships cp314 wheels for every platform, which was the last blocker for 3.14. All other extras already had cp314 support, and the full `dev,full,step-light` suite passes locally on 3.14.2.

- Add `3.14` to the test matrix, drop the "intentionally absent" comment in `ci.yml`.
- Update README Python support line to `3.10 – 3.14`.