### PR TITLE
Fix the docs build's example-dataset downloads

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -43,7 +43,24 @@ jobs:
       - name: Install with [docs]
         run: uv sync --extra docs
 
+      # The gallery executes every example, so it fetches the whole
+      # `pyvista_cad.examples.downloads` registry on a cold runner. That
+      # made the build hostage to the slowest upstream of the day: NIST
+      # has served the multi-MB STEP fixtures slowly enough to blow the
+      # HTTP read timeout and fail the job outright. Same cache strategy
+      # the `test` jobs in ci.yml already use: the sha256-pinned registry
+      # in downloads.py is a complete cache key.
+      - name: Cache example datasets
+        uses: actions/cache@v6
+        with:
+          path: ${{ github.workspace }}/.pooch-cache/pyvista_cad
+          key: pooch-${{ runner.os }}-${{ hashFiles('src/pyvista_cad/examples/downloads.py') }}
+          restore-keys: |
+            pooch-${{ runner.os }}-
+
       - name: Build documentation
+        env:
+          PYVISTA_CAD_USERDATA_PATH: ${{ github.workspace }}/.pooch-cache/pyvista_cad
         run: uv run make -C doc html
 
       - name: Prevent Jekyll processing on GH Pages

--- a/src/pyvista_cad/examples/downloads.py
+++ b/src/pyvista_cad/examples/downloads.py
@@ -124,8 +124,17 @@ _POOCH = pooch.create(
 )
 
 
+# pooch's default HTTP read timeout is 30 s, which several of these
+# hosts exceed under load. data.nist.gov in particular has served the
+# multi-megabyte STEP fixtures at ~38 s, failing every retry and taking
+# the docs gallery build down with it. The retries above only help when
+# a request fails fast; they cannot rescue a budget that is simply too
+# short.
+_DOWNLOADER = pooch.HTTPDownloader(timeout=120)
+
+
 def _fetch(name: str) -> str:
-    return str(_POOCH.fetch(name))
+    return str(_POOCH.fetch(name, downloader=_DOWNLOADER))
 
 
 def step_part_path() -> str:


### PR DESCRIPTION
## Summary

The docs gallery build has failed three times in a row on #31 and once earlier, always the same way: pooch gives up fetching the NIST STEP fixtures, an example raises, and Sphinx fails the job.

```
requests.exceptions.ReadTimeout: HTTPSConnectionPool(host='data.nist.gov', port=443): Read timed out. (read timeout=30)
```

`data.nist.gov` is not down. It answers 200, just slowly: fetching `AMB2022-01-AMMT-PlateLayoutAssy.STEP` by hand right now takes 36.6 s, which is past pooch's 30 s default read timeout. `retry_if_failed=3` cannot help, because every attempt hits the same wall.

Resolves #34.

## Details

- `_fetch` now goes through an `HTTPDownloader` with a 120 s read timeout. That is the whole fix for the immediate failure, and it is verified against the live host rather than reasoned about.
- The docs workflow now caches the pooch directory, using the same strategy the `test` jobs in `ci.yml` have had all along: point `PYVISTA_CAD_USERDATA_PATH` at a workspace path and key the cache on `downloads.py`. The registry is sha256-pinned, so a registry change rotates the key and a stale entry cannot serve wrong bytes. Only `docs.yml` was missing this, which is why the gallery build was the job that kept breaking.
- This edits `downloads.py`, so it rotates the existing `test`-job cache key once. `restore-keys` absorbs that.

The `ALLOW_PLOTTING` mitigation for the separate leaked-`Popen` flake in #32 is deliberately not here. Different failure, and it changes pyvista's behavior under test rather than just its network budget, so it deserves its own review.
